### PR TITLE
Intellisense now works with gitpod

### DIFF
--- a/.theia/launch.json
+++ b/.theia/launch.json
@@ -1,6 +1,0 @@
-{
-  // Use IntelliSense to learn about possible attributes.
-  // Hover to view descriptions of existing attributes.
-  "version": "0.2.0",
-  "configurations": []
-}

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,17 +1,22 @@
 {
     "configurations": [
         {
-            "name": "Linux",
-            "includePath": [
-                "${workspaceFolder}/include"
-            ],
-            "defines": [
-                "GITPOD"
-            ],
+            "name": "Gitpod",
+            "defines": [],
             "compilerPath": "/usr/bin/gcc",
             "cStandard": "c11",
             "cppStandard": "c++17",
-            "intelliSenseMode": "clang-x64"
+            "intelliSenseMode": "clang-x64",
+            "limitSymbolsToIncludedHeaders": true,
+            "includePath": [
+                "./include"
+                ],
+            "browse":
+            {
+                "path": [
+                    "./include"
+                    ]
+            }
         }
     ],
     "version": 4


### PR DESCRIPTION
The include path for the configuration works for the editor
but the browse path must also be added